### PR TITLE
Grammar fixes for tomland blog post

### DIFF
--- a/posts-raw/2018-07-11-typerep-map-step-by-step.md
+++ b/posts-raw/2018-07-11-typerep-map-step-by-step.md
@@ -1,7 +1,7 @@
 ---
 title: "typerep-map step by step"
 author: Veronika Romashkina
-tags: haskell, dependent types, typerep, data structure
+tags: haskell, dependent types, typerep, data structure, GADTs
 ---
 
 Recently, I have been working on a very interesting and sophisticated project

--- a/posts-raw/2019-01-14-tomland.md
+++ b/posts-raw/2019-01-14-tomland.md
@@ -1,17 +1,17 @@
 ---
 title: "tomland: Bidirectional TOML serialization"
 author: Dmitrii Kovanikov
-tags: haskell, TOML, GADT, profunctor, data structure
+tags: haskell, TOML, GADTs, profunctor, data structure
 ---
 
 `tomland` is a bidirectional TOML parsing and pretty-printing library.
-Bidirectional here means that the library allows to specify in one place how to
-convert Haskell data types to TOML format and how to parse TOML configurations
-to custom user types. This approach allows to eliminate one layer of bugs,
-specifically, when you update your data type and only single part of conversion
-(for example, parser) but accidentally forget to update the other one (printer).
-With bidirectional approach implemented in `tomland` you don’t have the chance
-to miss anything.
+"Bidirectional" here means that the library allows the user to specify in one
+place how to convert Haskell data types to TOML format and how to parse TOML
+configurations to custom user types. This approach allows eliminating one layer
+of bugs, specifically, when you update your data type and only one part of the
+conversion (for example, parser) but accidentally forget to update the other one
+(printer). With the bidirectional approach implemented in `tomland` there's no
+chance of you overlooking anything.
 
 Here is just a quick look at how those bidirectional parsers look like in code:
 
@@ -31,12 +31,12 @@ You can see a bigger example in the repository README:
 
 * [kowainik/tomland](https://github.com/kowainik/tomland)
 
-The idea is straightforward but the implementation requires some tricks. As the
-result, in order to provide convenient and type-safe interfaces `tomland` uses
-the following non-trivial Haskell techniques:
+The idea is straightforward but the implementation requires some tricks. As a
+result of this, in order to provide convenient and type-safe interfaces
+`tomland` uses the following non-trivial Haskell techniques:
 
-1. **GADT** and existential wrappers for core types and theorem-proving for more
-   compile-time guarantees.
+1. **GADTs** and existential wrappers for core types and theorem-proving for
+   more compile-time guarantees.
 2. Category theory and
    [Category](https://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Category.html)
    instance for the custom data type in order to implement [**tagged partial
@@ -50,11 +50,11 @@ the following non-trivial Haskell techniques:
 6. Type-safe **EDSL** for specifying TOML AST.
 
 Despite the fact that a lot of fancy features are used, the library is still
-well-tested. The whole code of the library itself contains 1600 LOC and 1100 LOC
-of tests in addition. But without the powerful Haskell type system, the size of
-such tests could be much bigger.
+well-tested. The whole code of the library itself comprises 1600 LOC and 1100
+LOC of tests. But without the powerful Haskell type system, the size of such
+tests could be much bigger.
 
-This blog post describes architecture and details of the implementation of
+This blog post describes the architecture and details of the implementation of
 `tomland`.
 
 ## Why bidirectional TOML?
@@ -63,7 +63,7 @@ TOML is great for static configurations. Its specification is very simple but
 expressive enough to cover most cases. Also, it’s unambiguous and human-readable
 which makes it much smoother to read and edit the configuration.
 
-The state of TOML parsing libraries in the Haskell ecosystem still can be
+The state of TOML parsing libraries in the Haskell ecosystem can still be
 improved. There are already several libraries:
 
 * [htoml](http://hackage.haskell.org/package/htoml)
@@ -72,64 +72,66 @@ improved. There are already several libraries:
 * [toml-parse](https://github.com/pliosoft/toml-parse)
 * [toml](https://hackage.haskell.org/package/toml)
 
-But not all of them have nice ways to convert TOML AST to custom Haskell types.
-Also, for example, `htoml` implements this conversion via `ToJSON/FromJSON`
+But not all of them have nice ways to convert a TOML AST to custom Haskell
+types. For example, `htoml` implements this conversion via `ToJSON/FromJSON`
 typeclasses from the `aeson` library and you might not always want to have extra
-dependencies if you don’t need JSON. Also, none of the libraries has
+dependencies if you don’t need JSON. Also, none of the libraries have
 pretty-printing abilities. Usually, you don’t need pretty-printing for TOML but
 there were at least two use-cases in my experience where I needed
 pretty-printing:
 
-1. [summoner](https://github.com/kowainik/summoner): Summoner allows to scaffold
-   modern Haskell projects. It can read TOML configuration where you can specify
-   some settings in advance. But for the moment, you need to write this TOML
-   config file manually. Though there are plans to implement a feature that
-   allows you to build your configuration settings interactively via `summoner`
-   itself and for this we need an ability to convert `Settings` data type to
-   TOML configuration.
+1. [summoner](https://github.com/kowainik/summoner): Summoner is the tool for
+   scaffolding modern Haskell projects. It can read TOML configuration where you
+   can specify some settings in advance. But for the moment, you need to write
+   this TOML config file manually. Though there are plans to implement a feature
+   that allows you to build your configuration settings interactively via
+   `summoner` itself and for this we need an ability to convert the `Settings`
+   data type to TOML configuration.
 2. [life-sync](https://github.com/kowainik/life-sync): this tool allows you to
    sync your configs across multiple machines. It stores all tracked files in
    its own TOML configuration file. In order to keep this file up-to-date,
-   `life-sync` needs not only to parse from this configuration but to convert
-   Haskell types to TOML.
+   `life-sync` needs to parse from this configuration file and it needs to
+   convert its Haskell types to TOML.
 
-I’m not going to compare TOML with JSON/YAML/Dhall, this is out of the scope for
-this blog post. Instead, let’s dive into library implementation details.
+I’m not going to compare TOML with JSON/YAML/Dhall, as that is not in the scope
+of this blog post. Instead, let’s dive into the implementation details of the
+library.
 
 ## Core architecture of Tomland
 
 ### Key concepts
 
-Below I’m going to mention key architecture decisions behind `tomland`:
+Below I’m going to mention the key architecture decisions behind `tomland`:
 
-1. Function-based approach for description of how to convert Haskell data types
-   to/from TOML instead of typeclasses-based approach. This approach has a lot
-   of pleasant advantages for decoding libraries: no orphan instances and no
-   ambiguity when there are multiple options for conversion. Here `tomland` goes
-   in one line with libraries like
+1. A function-based approach for the description of how to convert Haskell data
+   types to/from TOML instead of a typeclasses-based approach. This approach has
+   a lot of pleasant advantages for decoding libraries: no orphan instances and
+   no ambiguity when there are multiple options for conversion. Here `tomland`
+   goes along with libraries like
    [hedgehog](http://hackage.haskell.org/package/hedgehog),
    [sv](http://hackage.haskell.org/package/sv) and
    [waargonaut](http://hackage.haskell.org/package/waargonaut).
 2. Two-phase approach: parsing (from text to intermediate AST) and decoding
-   (from AST to custom user types). The similar way for pretty-printing.
-3. Make invalid states unrepresentable: TOML supports arrays of values. But TOML
-   specification also forbids to have heterogeneous arrays. This is captured at
-   the compile time by `tomland`.
-4. Parser combinators for parsing: `tomland` uses modern parsing library
+   (from AST to custom user types). And similarly for pretty-printing.
+3. Make invalid states unrepresentable: TOML supports arrays of values. But the
+   TOML specification also forbids us from having heterogeneous arrays. This is
+   captured at compile time by `tomland`.
+4. Parser combinators for parsing: `tomland` uses the modern parsing library
    [megaparsec](http://hackage.haskell.org/package/megaparsec).
 
 ### Type checking TOML
 
-It was mentioned at the beginning that `tomland` uses
-[GADT](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#generalised-algebraic-data-types-gadts)
-to represent AST. Let’s look at this part closer. When you want to convert
-unstructured runtime data to GADT in Haskell you have to use 2-step approach:
+It was mentioned earlier that `tomland` uses
+[GADTs](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/glasgow_exts.html#generalised-algebraic-data-types-gadts)
+to represent AST. Let’s take a closer look at this. When you want to convert
+unstructured runtime data to a GADT in Haskell you have to use a 2-step
+approach:
 
-1. Parse this data to plain old ADT.
-2. Type check simple ADT to GADT.
+1. Parse this data into a plain old ADT.
+2. Type check a simple ADT to a GADT.
 
 TOML has several primitive types, but let’s just consider `Integer`, `Text` and
-`Array` for simplicity. Here is how ADT for untyped representation of TOML
+`Array` for simplicity. Here is how an ADT for untyped representation of TOML
 values looks like:
 
 ```haskell
@@ -139,8 +141,9 @@ data UValue
     | UArray [UValue]
 ```
 
-And here is GADT version of this data type, that guarantees that all elements of
-the array have the same type (it uses extensions `-XDataKinds` and `-XGADTs`):
+And here is a GADT version of this data type, that guarantees that all the
+elements of the array have the same type (it uses extensions `-XDataKinds` and
+`-XGADTs`):
 
 ```haskell
 data TValue = TInteger | TText | TArray
@@ -151,12 +154,12 @@ data Value (t :: TValue) where
     Array   :: [Value t] -> Value 'TArray
 ```
 
-Let’s assume, that we have already implemented a parser for `UValue` (instead of
+Let’s assume that we have already implemented a parser for `UValue` (instead of
 assuming you can also look [at the real
 code](https://github.com/kowainik/tomland/tree/master/src/Toml/Parser)). Now we
 need to convert `UValue` to `Value`. But it’s not that simple: (1) this
-operation can fail and (2) in compile-time we don’t know the type of resulted
-`Value`.
+operation can fail and (2) at compile-time we don’t know the type of the
+resulted `Value`.
 
 To overcome the second challenge, we need to introduce an existential wrapper
 around `Value`.
@@ -166,7 +169,7 @@ data AnyValue = forall (t :: TValue) . AnyValue (Value t)
 ```
 
 > **NOTE**: you can’t return `Value t` from the function but you can return
-> `AnyValue` since the type variable `t` is hidden inside `AnyValue`
+> `AnyValue` since the type variable `t` is hidden inside the `AnyValue`
 > constructor.
 
 Our conversion function can fail only because of a single reason: when elements
@@ -181,8 +184,8 @@ elements of the list have the same type is the following:
    we checked everything properly.
 
 First, let’s implement the `sameValue` function that checks whether two `Value`s
-have the same type. Here we’re going to use [propositional
-equality](https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Type-Equality.html#t::-126-:)
+have the same type. Here we’re going to use
+[propositional equality](https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Type-Equality.html#t::-126-:)
 which is implemented in the following way:
 
 ```haskell
@@ -213,7 +216,7 @@ sameValue l         r         = Left $ TypeMismatchError
                                          }
 ```
 
-Now we’re ready to implement the proper simple type checking algorithm!
+Now we’re ready to implement a proper simple type checking algorithm!
 
 ```haskell
 typeCheck :: UValue -> Either TypeMismatchError AnyValue
@@ -233,15 +236,15 @@ typeCheck (UArray a)   = case a of
         (v :) <$> checkElem vx xs
 ```
 
-In order to convince GHC that elements of the array have the same type, we
-pattern match on `Refl`. After this pattern matching GHC can see type equality
-between given element and the head of the list. That’s why we can put them in
-the same list.
+In order to convince GHC that the elements of the array have the same type, we
+pattern match on `Refl`. After this pattern matching GHC can see the type
+equality between the given element and the head of the list. That’s why we can
+put them in the same list.
 
 ### Prefix tree
 
-We managed to deal only with values. But in TOML values assigned to textual
-keys. Here is some TOML example:
+We managed to deal only with values. But in TOML, values are assigned to textual
+keys. Here is an example of this:
 
 ```toml
 server.id    = 42
@@ -249,15 +252,15 @@ server.host  = "best-haskell-blog.com"
 server.ports = [8080, 8081, 9080, 9081]
 ```
 
-Here `server.ports` is a key and it has a value of the array of integers. Keys
-are represented in the following way in `tomland`:
+Here `server.ports` is a key and its corresponding value is an array of
+integers. Keys are represented in the following way in `tomland`:
 
 ```haskell
 newtype Piece = Piece { unPiece :: Text }
 newtype Key = Key { unKey :: NonEmpty Piece }
 ```
 
-Keys in TOML are dot-separated words. If some keys share common prefix they
+Keys in TOML are dot-separated words. If some keys share a common prefix, they
 semantically belong to the same object (though you don’t have to follow this
 rule, it helps readability a lot). TOML also has tables that help to visually
 separate parts of the static configuration. Here is an example of tables and
@@ -275,11 +278,11 @@ nested tables:
         ports = [9080, 9081]
 ```
 
-To represent this structure nicely we need some prefix tree. There’re several
+To represent this structure nicely we need some prefix tree. There are several
 libraries on Hackage that implement very decent prefix trees but unfortunately,
-none of them fits our use-case. So we decided to implement our own data
-structure. It has the following shape using two mutually recursive data
-structures:
+none of them fit our use-case. So we decided to implement our own data
+structure. It has the following shape (using two mutually recursive data
+structures):
 
 ```haskell
 type Prefix = Key
@@ -291,10 +294,10 @@ data PrefixTree a
     | Branch Prefix (Maybe a) (PrefixMap a)
 ```
 
-When we want to insert a new key into `PrefixTree` we need to split given key
-and key inside the current tree node into common and remaining parts and then
-split the current node properly. The result of finding key prefixes is captured
-by the following data type:
+When we want to insert a new key into `PrefixTree`, we need to split the given
+key and the key inside the current tree node into `common` and `remaining` parts
+and then split the current node properly. The result of the routine that finds
+key prefixes is captured by the following data type:
 
 ```haskell
 data KeysDiff
@@ -320,7 +323,7 @@ Every TOML configuration stores the following items:
 3. Zero or more array of tables.
 
 The structure of TOML is recursive. So every table and array of tables has the
-same structure. That’s why TOML AST is represented in the following way:
+same structure. That’s why a TOML AST is represented in the following way:
 
 ```haskell
 data TOML = TOML
@@ -330,25 +333,26 @@ data TOML = TOML
     }
 ```
 
-That’s all regarding TOML AST! The following sections of this tutorial cover
+That’s all regarding TOML AST! The following sections of this tutorial cover the
 bidirectional conversion aspect of the library.
 
 ## Tagged partial bidirectional isomorphism
 
 First, we need to learn how to switch between basic Haskell types and `AnyValue`
 in both directions. Converting from `Text` to `AnyValue` is pretty simple. Just
-apply `Text` constructor of `Value` and then wrap into `AnyValue`. However,
+apply the`Text` constructor of `Value` and then wrap into `AnyValue`. However,
 conversion from `AnyValue` to `Text` may fail because there might be a different
-constructor. Turns out that conversion to `AnyValue` also may fail. Consider
+constructor. It turns out that conversion to `AnyValue` may also fail. Consider
 `ByteString`: in order to convert `ByteString` to `AnyValue` you first need to
 convert it to `Text` and this operation may fail. Alternatively, you can convert
 `ByteString` to the array of integers.
 
 You can see now that we need a way to convert types in both directions. Just
-like isomorphisms, but conversion in both directions may fail. Thus it’s
-partial. And we also want to tell our users good error messages. So this is
-actually _tagged partial bidirectional isomorphism_. In `tomland` this concept
-is captured by the following data type with a much shorter name:
+like isomorphisms, with the only difference that the conversion in both
+directions may fail. Thus it’s partial. And we also want to report good error
+messages to our users. So this is actually _tagged partial bidirectional
+isomorphism_. In `tomland` this concept is captured by the following data type
+with a much shorter name:
 
 ```haskell
 data BiMap e a b = BiMap
@@ -362,10 +366,10 @@ following graph:
 
 ![BiMap illustration](https://user-images.githubusercontent.com/4276606/50770531-b6a36000-1298-11e9-9528-caae87951d2a.png)
 
-Type parameters `a` and `b` represent values between which we’re converting. And
-`e` is the type of error.
+Type parameters `a` and `b` represent the values between which we’re converting.
+And `e` is the type of error.
 
-> In `tomland` `BiMap` is specialized to the following error type:
+> **NOTE:** In `tomland` `BiMap` is specialized to the following error type:
 >
 > ```haskell
 > data TomlBiMapError
@@ -376,19 +380,19 @@ Type parameters `a` and `b` represent values between which we’re converting. A
 > type TomlBiMap = BiMap TomlBiMapError
 > ```
 
-When we want to write bidirectional mapping between `Text` and `AnyValue` we
+When we want to write a bidirectional mapping between `Text` and `AnyValue` we
 need to provide two functions. If we want to do the same for `ByteString` and
-`AnyValue` we can implement the similar two functions. But you may notice that
-the logic for the `Text` converter is the subset of the logic for the
-`ByteString` converter.
+`AnyValue` we can implement two similar functions But you may notice that the
+logic for the `Text` converter is a subset of the logic for the `ByteString`
+one.
 
-Turns out, that `BiMap` composes very nicely! And we can write only `BiMap`
-between `ByteString` and `Text` and compose it with `BiMap` between `Text` and
-`AnyValue`. This is possible thanks to the following
+It turns out that `BiMap` composes very nicely! And we need to write only
+`BiMap` between `ByteString` and `Text` and compose it with `BiMap` between
+`Text` and `AnyValue`. This is possible thanks to the following
 [`Category`](https://hackage.haskell.org/package/base-4.12.0.0/docs/Control-Category.html)
-instance for `BiMap` because `BiMap` forms category. `Category` allows to
-compose objects of type `Type -> Type -> Type` but for that, you need to
-implement the composition operator and identity object which is a neutral
+instance for `BiMap` because `BiMap` forms category. `Category` allows us to
+compose objects of the type `Type -> Type -> Type`, but for that, you need to
+implement the composition operator and the identity object which is a neutral
 element for composition.
 
 ```haskell
@@ -403,14 +407,14 @@ instance Category (BiMap e) where
         }
 ```
 
-This instance can be clearly described by the following picture:
+This instance can be described clearly by the following picture:
 
 ![Category composition illustration](https://user-images.githubusercontent.com/4276606/50771234-13a01580-129b-11e9-93da-6c5dd0f7f160.png)
 
 It’s not convenient to use the dot-operator from `Control.Category` to compose
 `BiMap`s because this operator is already specialized to arrow `(->)` in
-`Prelude`. But we still can use operators `>>>` and `<<<` for composing objects
-and this is quite nice!
+`Prelude`. But we still can use the ‘>>>’ and ‘<<<’ operators for composing
+objects and this is quite nice!
 
 ```haskell
 _ByteStringText :: TomlBiMap ByteString Text
@@ -426,13 +430,13 @@ you want to use it on common data structures.
 
 ## Codec
 
-At this moment we can convert between primitive types and TOML values. But
-usually, in Haskell, we work with a lot of custom data types, including both
-product and sum types. This section covers how to compose different `BiMap` into
-a single bidirectional converter for a Haskell data type.
+As of now, we are converting between primitive types and TOML values. But
+usually, in Haskell, we work with a lot of custom data types, including both,
+product and sum types. This section covers how to compose different `BiMap`s
+into a single bidirectional converter for a Haskell data type.
 
 The idea for bidirectional converters is not new. It’s based on the approach
-called _monadic profunctors_ and described in details in this blog post:
+called _monadic profunctors_ and is described in detail in this blog post:
 
 * [Towards monadic bidirectional serialization](https://blog.poisson.chat/posts/2016-10-12-bidirectional-serialization.html)
 * [Monadic profunctors for bidirectional programming](https://blog.poisson.chat/posts/2017-01-01-monadic-profunctors.html)
@@ -458,36 +462,36 @@ data Codec r w c a = Codec
 
 It looks scary but I will try to explain its meaning.
 
-* `r` is usually some `Reader` monad. It stores intermediate AST representation
-  inside the context which we’re going to query to fetch pieces of our big
-  custom user type.
+* `r` is usually some `Reader` monad. It stores an intermediate AST
+  representation inside the context which we’re going to query to fetch pieces
+  of our big custom user type.
 * `w` is some `Writer` or `State` which stores the result of converting a
-  current piece of custom user type to intermediate AST.
+  current piece of custom user type to an intermediate AST.
 * `a` is the type that we’re converting. For example, `Integer`, `Text` or
   `Person`.
 * `c` is a fake type variable which is required in order to make this magic
-  works. It should be equal to `a` but if we make it `a` immediately in the type
-  definition we won’t be able to write required instances.
+  work. It should be equal to `a` but if we make it `a` directly in the type
+  definition, we won’t be able to write the required instances.
 
 `Codec` has `Functor`, `Applicative`, `Monad`, `Alternative` and `Profunctor` instances.
 
-> **NOTE:** `Profunctor` instance is not implemented in `tomland` because,
-> currently, it requires to add
-> [profunctors](https://hackage.haskell.org/package/profunctors) package to
-> dependencies; this makes `tomland` heavier but it’s not that necessary to have
-> this instance, it’s enough to just have functions from this instance, so we
-> can wait until `Profunctor` migrates to `base`. There is an open GHC ticket
-> for this:
+> **NOTE:** The `Profunctor` instance is not implemented in `tomland` because,
+> currently, it requires the addition of the
+> [profunctors](https://hackage.haskell.org/package/profunctors) package to our
+> dependencies; this would make `tomland` heavier, but it’s not that necessary
+> to have this instance, it’s enough to just have functions from this instance,
+> so we can wait until the `profunctors` package is migrated to `base`. At the
+> time of writing, there is an open GHC ticket for this:
 >
 > * [ghc/trac/16173](https://ghc.haskell.org/trac/ghc/ticket/16173#ticket)
 
 The type of `codecWrite` semantically should be equivalent to `a -> w ()`: we
-take a value of our type `a`, change the context and ignore the result. But if
-we do so, we’re not able to implement a convenient interface that we want.
+take a value of our type `a`, change the context, and ignore the result. But if
+we do so, we’re not able to implement a desirable, convenient interface.
 
 Another way to look at `Codec`: it is just a special case of
 [Product](https://hackage.haskell.org/package/base-4.12.0.0/docs/Data-Functor-Product.html)
-monad. Here is a quick reminder of what `Product` data type is:
+monad. Here is a quick reminder of what the `Product` data type is:
 
 ```haskell
 data Product f g a = Pair (f a) (g a)
@@ -499,21 +503,20 @@ instance (Monad f, Monad g) => Monad (Product f g) where
         sndP (Pair _ b) = b
 ```
 
-So `Codec` semantically equivalent to the following `Product` specialization:
+So `Codec` is semantically equivalent to the following `Product` specialization:
 
 ```haskell
 type Codec r w c a = Product r (ReaderT c w) a
 ```
 
 `Product` stores two monadic actions and performs operations over them in
-parallel. So at one step of `>>=` it changes both monads. But changes are
-parallel, they are independent. This means, that you can describe two monadic
-actions in a single place but later you can choose to work only with one of
-them.
+parallel. So at one step of `>>=` it changes both monads. But the changes are
+parallel and independent. This means that you can describe two monadic actions
+in a single place, but later you can choose to work with only one of them.
 
-It’s an interesting and not that difficult exercise to implement `Functor`,
-`Applicative` and `Monad` instances for `Codec`. So let’s look closer at `dimap`
-from profunctor part:
+It’s an interesting (and not that difficult) exercise to implement the
+`Functor`, `Applicative`, and `Monad` instances for `Codec`. So let’s look
+closer at `dimap` from profunctor part:
 
 ```haskell
 dimap
@@ -534,7 +537,7 @@ In real life we’re going to substitute `a` in place of `c`:
 type BiCodec r w a = Codec r w a a
 ```
 
-So simpler version of `dimap` for `BiCodec` looks like this:
+So, a simpler version of `dimap` for `BiCodec` looks like this:
 
 ```haskell
 dimap
@@ -549,11 +552,12 @@ dimap f g codec = Codec
   }
 ```
 
-Now the idea behind `Profunctor` became much clearer! If we have a bidirectional
-converter for a value of type `a` and we have two pure functions to convert from
-`a` to `b` and vice versa we can have a bidirectional converter for `b`.
+Now the idea behind `Profunctor` becomes much clearer! If we have a
+bidirectional converter for a value of type `a` and we have two pure functions
+to convert from `a` to `b` and vice versa we can have a bidirectional converter
+for `b`.
 
-There’s only single important piece left: convenient operator to compose
+There’s only a single important piece left: a convenient operator to compose
 different `Codec`s:
 
 ```haskell
@@ -562,14 +566,14 @@ infixl 5 .=
 codec .= getter = codec { codecWrite = codecWrite codec . getter }
 ```
 
-Attentive reader may notice that `(.=)` operator is
+An attentive reader may notice that the `(.=)` operator is
 [lmap](https://hackage.haskell.org/package/profunctors-5.3/docs/Data-Profunctor.html#v:lmap)
 from `Profunctor` typeclass.
 
 ### TOML codec
 
-We covered only general data type but it’s beneficial for understanding to see
-how it is specialized to write bidirectional codecs for TOML:
+We covered only general data types but it’s beneficial for our understanding to
+see how it is specialized to write bidirectional codecs for TOML:
 
 ```haskell
 type Env = ExceptT DecodeException (Reader TOML)
@@ -577,8 +581,8 @@ type St = MaybeT (State TOML)
 type TomlCodec = BiCodec Env St
 ```
 
-Our `r` variable stores TOML AST inside the context and can return an error. So
-`r a` in `Codec` specializes to:
+Our `r` variable stores a a TOML AST inside the context and can return an error.
+So `r a` in `Codec` specializes to:
 
 ```haskell
 codecRead @tomland :: TOML -> Either DecodeException a
@@ -597,9 +601,9 @@ codecWrite @tomland :: a -> TOML -> (Maybe a, TOML)
 > [more efficient to use `State`](https://blog.infinitenegativeutility.com/2016/7/writer-monads-and-space-leaks).
 
 Now we need a function that can lift `TomlBiMap` to `TomlCodec`. But this
-function requires the key. It will lookup `TOML` AST to find `AnyValue` under
-given `Key` and then it will try to convert `AnyValue` according to given
-`BiMap`. This function is called simply `match` in `tomland`:
+function requires a key. It will lookup `TOML` AST to find `AnyValue` under
+given `Key` and then it will try to convert `AnyValue` according to the given
+`BiMap`. This function is simply called `match` in `tomland`:
 
 ```haskell
 match :: TomlBiMap a AnyValue -> Key -> TomlCodec a
@@ -618,17 +622,18 @@ arrayOf :: TomlBiMap a AnyValue -> Key -> TomlCodec [a]
 arrayOf = match . _Array
 ```
 
-Note how we managed to decompose the problem of finding value under a key and
+Note how we managed to decompose the problem of finding a value under a key and
 converting this value to Haskell type into two separate problems. `BiMap` takes
 care of all errors during conversion between types and doesn’t know anything
 about TOML and keys. And `match` doesn’t know what value we’re working with
-(because of parametric polymorphism), all it does is just lookups required key
-inside the map and handles cases whether the key is found or not. For
-pretty-printing `match` inserts the value under the given key.
+(because of parametric polymorphism), all it does is, it just looks up the
+required key inside the map and handles the two resulting cases: when the key is
+found and when it is not. For pretty-printing, `match` inserts the value under
+the given key.
 
-Tables in TOML can be used to represent codecs for the nested data structures.
-Remember the example with `production` and `staging` TOML server? Here is how
-`Codec` for this data type looks like:
+Tables in TOML can be used to represent codecs for nested data structures.
+Remember the example with the `production` and `staging` TOML servers? Here is
+how the`Codec` for this data type looks like:
 
 ```haskell
 data Settings = Settings
@@ -654,14 +659,15 @@ serverConfigCodec = flip Toml.table "server" $ ServerConfig
     <*> Toml.table settingsCodec "staging"    .= settingsStaging
 ```
 
-You may see that most of the time we’re using `Applicative` instance of `Codec`
-despite the fact that approach is called _monadic profunctors_. But turns out
-that applicative functors are more convenient here. Though, of course, you can
-do a lot of fun with `Monad` instance as well. For example, configuration can
-contain a field with a key name like `spec-version` and the value of this field
-determines how this particular configuration should be parsed.
+You may notice that most of the time we’re using `Applicative` instance of
+`Codec`, despite the fact that this approach is called _monadic profunctors_.
+But, it turns out that applicative functors are more convenient here. Though, of
+course, you can have a lot of fun with the `Monad` instance as well. For
+example, configuration can contain a field with a key name like `spec-version`
+and the value of this field determines how this particular configuration should
+be parsed.
 
-And here is a couple of examples with possible error messages:
+And here are a couple of examples with possible error messages:
 
 ```haskell
 ghci> showRes = either print print
@@ -705,9 +711,9 @@ table :: Key -> TDSL -> TDSL
 table k = modify . insertTable k . mkToml
 ```
 
-However, we need a couple of extra instances to make API more convenient to work
-with. Due to the fact that our `Value` is GADT, we can implement type-safe
-instances for sum types!
+However, we need a couple of extra instances to make the API more convenient to
+work with. Due to the fact that our `Value` is a GADT, we can implement
+type-safe instances for sum types!
 
 ```haskell
 instance (t ~ 'TInteger) => Num (Value t) where
@@ -735,30 +741,31 @@ serverToml = table "server" $ do
         "id"    =: 42
         "host"  =: "best-haskell-blog.com"
         "ports" =: Array [8080, 8081]
-    table “staging” $ do
+    table "staging" $ do
         "id"    =: 777
         "host"  =: "okayish-haskell-blog.com"
         "ports" =: Array [9080, 9081]
 ```
 
-This is very useful for testing where you want to test conversion but you don’t
-want to deal with parsing. With EDSL you can create TOML AST which is guaranteed
-to be correct and safe by construction.
+This is very useful for testing when you want to test conversion but you don’t
+want to deal with parsing. With EDSL you can create a TOML AST which is
+guaranteed to be correct and safe by the construction.
 
 ## Tests
 
 You may notice that `tomland` was written with the help of a lot of heavy tools.
 But types don’t substitute tests, so we have **A LOT** of them. I will shortly
-describe what we test in `tomland` to ensure you that we care very much about
+describe what we test in `tomland` to assure you that we care very much about
 the correctness of this library. `tomland` is already used in production and in
 commercial projects so it’s necessary to have reliable tests.
 
-1. Unit tests for parsing. TOML specification is relatively small, but still,
-   there’re a lot of things to keep an eye on it. We have ~600 LOC of unit tests
-   for parsing only. And we test not only that we properly parse correct TOML
-   but we also test that we don’t parse incorrect TOML.
-2. Unit tests for `PrefixTree` on `lookup` and `insert`
-3. Property tests for `PrefixTree` on `insert` with `lookup`
+1. Unit tests for parsing. The TOML specification is relatively small, but
+   still, there’re a lot of things to keep an eye on. We have ~600 LOC of unit
+   tests for parsing only. And we test not only that we parse correct TOML
+   (files) successfully, but also that we parse incorrect TOML files
+   unsuccessfully (with good error-reporting).
+2. Unit tests for `PrefixTree` on `lookup` and `insert`.
+3. Property tests for `PrefixTree` on `insert` with `lookup`.
 4. Property tests for `PrefixTree` for `Semigroup` laws.
 5. Property tests for TOML on `Semigroup` and `Monoid` laws.
 6. Roundtrip property tests for parsing and printing TOML AST.
@@ -768,10 +775,11 @@ commercial projects so it’s necessary to have reliable tests.
 
 ## Benchmarks
 
-And we also have benchmarks to compare with other libraries! Not all libraries
-are still maintained. That’s why there are some difficulties to build them on
-newer GHC versions, so `tomland` is compared only with `htoml`,
-`htoml-megaparsec` and `toml-parser`. Here is the performance table:
+And we also have benchmarks to compare `tomland` with other libraries! Not all
+libraries are being actively maintained, so there were some difficulties in
+building them on newer GHC versions, therefore we have only compared `tomland`
+with `htoml`, `htoml-megaparsec`, and `toml-parser`. Here is the performance
+table:
 
 | Library            | parse :: Text -> AST | transform :: AST -> Haskell |
 |--------------------|----------------------|-----------------------------|
@@ -780,31 +788,32 @@ newer GHC versions, so `tomland` is compared only with `htoml`,
 | htoml-megaparsec   | 318.7 μs             | 34.74 μs                    |
 | toml-parser        | 157.2 μs             | 1.156 μs                    |
 
-You may see that `tomland` is not the fastest one (though still very fast). But
+You may see that `tomland` is not the fastest one (though still very fast), but
 performance hasn’t been optimized so far and:
 
-1. `toml-parser` doesn’t support the array of tables and because of that it’s
-   hardly possible to specify the list of custom data types in TOML with this
+1. `toml-parser` doesn’t support arrays of tables and because of that it’s
+   hardly possible to specify a list of custom data types in TOML with this
    library.
-2. `tomland` supports latest TOML spec while `htoml` and `htoml-megaparsec`
+2. `tomland` supports the latest TOML spec while `htoml` and `htoml-megaparsec`
    don’t have support for all types, values and formats.
 3. `tomland` is the only library that has pretty-printing.
-4. `toml-parser` doesn’t have ways to convert TOML AST to custom Haskell types
-   and `htoml*` libraries use typeclasses-based approach via `aeson` library.
+4. `toml-parser` doesn’t have ways to convert a TOML AST to custom Haskell types
+   and `htoml*` libraries use a typeclasses-based approach via `aeson` library.
 5. `tomland` is bidirectional :)
 
 ## Conclusion
 
-I hope that this blog post helps you to understand better some advanced topics
+I hope that this blog post helps you to better understand some advanced topics
 and Haskell in general. You can see how very different pieces of Haskell can be
-combined inside a single library and help to come up with the better
-architecture. Probably you can borrow some ideas for your next library. Or even
-give `tomland` a try for static configuration in your application!
+combined inside a single library and can help to come up with a better
+architecture. Probably you can borrow some ideas from `tomland` for your next
+library. Or even give `tomland` a try for static configuration in your
+application!
 
 ## Acknowledgment
 
 I want to say special thanks to [vrom911](https://github.com/vrom911),
 [willbasky](https://github.com/willbasky),
 [jiegillet](https://github.com/jiegillet) and
-[ghallak](https://github.com/ghallak) for massive help with `tomland` library!
-Their contribution is invaluable.
+[ghallak](https://github.com/ghallak) for their massive help with the `tomland`
+library! Their contribution is invaluable.


### PR DESCRIPTION
Applied fixes suggested by @kahlil29 to the `tomland` blog post.