### PR TITLE
[#87] Introduce short links for new blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ title: Some really meaningful title that will appear at the page
 author: Your Name
 tags: haskell, stack, cabal, build-tools, tutorial
 description: Some short description
+useShortName: yes
 ---
 
 DO NOT COPY TITLE HERE!

--- a/kowainik-site.cabal
+++ b/kowainik-site.cabal
@@ -68,7 +68,8 @@ executable site
   import:              common-options
   main-is:             site.hs
 
-  build-depends:       hakyll
+  build-depends:       filepath
+                     , hakyll
                      , kowainik-site
                      , pandoc
                      , pandoc-types


### PR DESCRIPTION
Resolves #87

This PR introduces a way to specify whether the blog post should be served under a short name or a long name. I used the same approach as @vrom911 in here blog post to shorten links. However, the code uses a short link for the blog post only if there is `useShortName: any text here` in the blog post metadata. This way we can preserve backwards compatibility: old blog posts will continue to be accessible under the long name but for new blog posts we need to add `useShortName` to have shorter names. Not sure that this is the best solution, so let me know what do you think!

I've tried to add shorter redirects for old posts (I did this in my blog post), however, this doesn't seem to work and I see the following error:
```
  [ERROR] Hakyll.Core.Compiler.Require.load: posts/backpack.html (snapshot content) was not found in the cache, the cache might be corrupted or the item you are referring to might not exist
```

So I've just commented out the code. It works if I don't add `posts/` prefix but I don't think we should serve blog posts on top-level and not under `posts/` for Kowainik...