### PR TITLE
Fix error in Naming conventions post (s/suffix/prefix)

### DIFF
--- a/posts/2020-12-13-naming-conventions.md
+++ b/posts/2020-12-13-naming-conventions.md
@@ -738,7 +738,7 @@ printPath mPath = case mPath of
 #### generic
 
 The standard library uses the
-[suffix `generic`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-List.html#g:26)
+[prefix `generic`](https://hackage.haskell.org/package/base-4.14.0.0/docs/Data-List.html#g:26)
 to provide functions that return polymorphic values or work with more
 polymorphic arguments. They are usually much slower, as a consequence,
 but in some cases, they are the best option.


### PR DESCRIPTION
Great post, thank you!

This adds a small fix where I think you meant prefix instead of suffix.