### PR TITLE
[#135] Sort by updated in blog posts

### DIFF
--- a/kowainik-site.cabal
+++ b/kowainik-site.cabal
@@ -72,6 +72,7 @@ library
                      , pandoc >= 2.9
                      , pandoc-types
                      , text
+                     , time
 
 executable site
   import:              common-options


### PR DESCRIPTION
Resolves #135

Now blog posts are sorted by the "updated" field as shown on the screenshots below. Open question: do we need to patch the display date on the page with all posts?

![Screenshot from 2021-04-26 16-58-31](https://user-images.githubusercontent.com/4276606/116114101-f7655400-a6b0-11eb-8743-545d5515bb8f.png)
![Screenshot from 2021-04-26 16-58-01](https://user-images.githubusercontent.com/4276606/116114108-f8968100-a6b0-11eb-92d6-e77f6d6312a5.png)

